### PR TITLE
Add mussel pollutant dataset

### DIFF
--- a/data/oc_mussel_pollutant_concentration.yaml
+++ b/data/oc_mussel_pollutant_concentration.yaml
@@ -1,0 +1,223 @@
+general:
+  datasetName: NCCOS Coastal Pollutants
+  creators: {}
+  # - name: Stanley Bishop
+  #   contact: science.stanley@stanley.science
+    - Team: Ocean optimizers  
+      Name: Aryama Singh 
+      Name: Maggie Swerdloff
+      Name: Meltem Uyanik
+      Name: Junaid Hasan
+      Name: Korel Gundem
+      Name: Aihemaiti Maitituerdi
+      Name: Noah Rahman
+  
+  
+    # - name: Arina Morozova 
+    #   contact: Arina.Morozova@noaa.gov 
+    # - name: Christine Addison 
+    #   contact: Christine.Addison@noaa.gov 
+    # - name: Mary Rider 
+    #   contact: Mary.Rider@noaa.gov 
+    # - name: Felipe Arzayus 
+    #   contact: Felipe.Arzayus@noaa.gov 
+    # - name: Dennis Apeti 
+    #   contact: Dennis.Apeti@noaa.gov
+
+  licensing:
+    acessType: Open
+    conditionalUsage:
+    licenseUrl: https://creativecommons.org/publicdomain/zero/1.0/
+    licenseType: CC0 1.0
+    licenseHolders: 
+      - National Centers for Coastal Ocean Science (U.S.)
+      - United States. National Ocean Service. Office of Response and Restoration
+    # if licensed/privileged, provide licensee info
+    # - name: John Smith
+    #   type: indivdual
+    #   expiry: perpetual
+    # - name: New Atlantis
+    #   type: organization
+    #   expiry: 12/12/2025
+
+  accessPattern: 
+  # - api
+  # - etc
+    - download link https://experience.arcgis.com/experience/e5ae2ee667e640c99ed85834291e83b2/page/Explore-All-MW-data/?views=Download-Data%2CLegacy
+
+  description: |
+    The Coastal Pollution Data Explorer (CPDE) is an interactive web-based interface where users can explore spatial and 
+    temporal trends of chemical, physical, biological, and toxicological data. Users can compare, analyze, graph, and download NCCOS 
+    contaminant data from 1986 to the present. https://experience.arcgis.com/experience/e5ae2ee667e640c99ed85834291e83b2/page/Metadata/?block_id=layout_699_block_2
+  keywords:
+    - legacy contaminants
+    - chemical contaminants
+    - biological stressors
+    - coastal waters
+    - EcoTox program
+    - Mussel watch
+    - pesticides
+    - trace metals
+    - Contaminants of emerging concern
+    - CEC
+    - Indivisual analytes
+
+  additionalInfo:
+    relatedDatasets:
+      - https://experience.arcgis.com/experience/e5ae2ee667e640c99ed85834291e83b2/page/Explore-All-MW-data/?views=Download-Data-%2CDownload-Data--%2CMetals
+      - https://experience.arcgis.com/experience/e5ae2ee667e640c99ed85834291e83b2/page/Explore-All-MW-data/?views=CEC%2CDownload-Data-
+    relatedPublications:
+      - Apeti, D.A., Johnson, W.E., Kimbrough, K.L. and Lauenstein, G.G., 2012. National Status and Trends Mussel Watch Program- Field Methods 2012 Update. NOAA National Centers for Coastal Ocean Science, Center for Coastal Monitoring and Assessment. NOAA NCCOS Technical Memorandum 134. Silver Spring, MD. 
+      - Apeti, D.A., Wirth, E., Leight, A.K., Mason, A., and Pisarski, E. 2018. An assessment of contaminants of emerging concern in the Chesapeake Bay, MD and Charleston Harbor, SC. NOAA Technical Memorandum NOS NCCOS 240. Silver Spring, MD. 104pp. doi:10.25923/p4nc7m71. 
+      - EPA (Environmental Protection Agency). 1992. Method 3005A (SW-846)- Acid Digestion of Waters for Total Recoverable or Dissolved Metals for Analysis by Flame AA or ICP Spectroscopy. Washington, DC U.S.EPA. https://www.epa.gov/sites/default/files/2015-12/documents/3005a.pdf 
+      - EPA (Environmental Protection Agency). 1994. Method 200.8 (SAM)- Determination of Trace Elements in Waters and Wastes by Inductively Coupled Plasma-Mass Spectrometry. Washington, DC U.S. EPA. https://www.epa.gov/sites/default/files/2015-06/documents/epa-200.8.pdf 
+      - EPA (Environmental Protection Agency). 1996. Method 3050B (SW-846)- Acid Digestion of Sediments, Sludges, and Soils. Washington, DC U.S. EPA. http://www.epa.gov/sites/production/files/2015-06/documents/epa-3050b.pdf - Kimbrough, K.L., Lauenstein, G.G. and and Johnson, W.E., 2006. Organic Contaminant Analytical Methods of the National Status and Trends Program 2000–2006. US Dept. Comm., NOAA Tech. Memo. 30, NOS NCCOS, Silver Spring, Maryland. 
+      - Kimbrough, K.L., Johnson, W.E., Lauenstein, G.G., Christensen, J.D. and Apeti, D.A. 2008. An assessment of two decades of contaminant monitoring in the nation’s coastal zone. Silver Spring, MD. NOAA Technical Memorandum NOS NCCOS 74:105. 
+      - Loyo-Rosales, J.E., I. Schmitz-Afonso, C.P. Rice, and A. Torrents. 2003. Analysis of octyl- and nonylphenol and their ethoxylates in water and sediments by liquid chromatography/tandem mass spectrometry. Analytical Chemistry 75:4811-4817. 
+      - Petrovic, M., E. Eljarrat, M.J. López de Alda, and D. Barceló. 2002. Recent advances in the mass spectrometric analysis related to endocrine disrupting compounds in aquatic environmental samples. Journal of Chromatography A 974:23-51.
+
+    contactInfo:
+
+metadata:
+  creationDate: '1986-01-01T00:00:00Z'
+  lastUpdated: '2024-12-31T23:59:59Z'
+
+  version: 0.1
+  versionControl:
+    # Git repository URL
+    repositoryUrl:
+    # Branch tags for this specific version of the data
+    branchTag:
+    # List of related issues
+    relatedIssues: []
+    # List of related pull requests
+    pullRequests: []
+  temporalCoverage:
+    begin: '1986-01-01T00:00:00Z'
+    end: '2024-12-31T23:59:59Z'
+
+  spatialCoverage:
+    geoJson:
+      type: FeatureCollection
+      features:
+      - type: Feature
+        geometry:
+          type: Point
+          coordinates: [-30.0000, 0.0000]
+        properties:
+          name: Middle of the Atlantic Ocean
+  dataFormat: csv
+  fileSize:
+  numberOfRecords: 38839
+  primaryDataType: coastasl contaminants # e.g., oceanographic profiles, sea level data, marine chemistry
+  dataQuality:
+    qualityControlProcedures: {}
+    # - name: foo
+    #   description: bar
+    knownIssues: {}
+    # - name: foo
+    #   description: bar
+    limitations: {}
+    # - name: foo
+    #   description: bar
+    processingSteps: {}
+    # - name: Normalization
+    #   description: Organizing data to minimize redundancy and improve data integrity by ensuring that data is stored logically and consistently
+
+
+  dataTypes:
+    # Uncomment and fill specific data type(s) info for dataset
+    oceanographicProfiles:
+    - profile1:
+        region: Atlantic Ocean
+        # Schema to populate GeoJSON fields 
+        geoJson:
+          type: FeatureCollection
+          features:
+          - type: Feature
+            geometry:
+              type: Polygon
+              coordinates:
+              - [-30.0000, 0.0000] # Point 1: Longitude, Latitude
+              - [-30.0000, 1.0000] # Point 2: Longitude, Latitude
+              - [-29.0000, 1.0000] # Point 3: Longitude, Latitude
+              - [-29.0000, 0.0000] # Point 4: Longitude, Latitude
+              - [-30.0000, 0.0000] # Closing the polygon
+            properties:
+              name: Mid-atlantic polygon
+        depthRange:
+          min:
+          max:
+        parametersMeasured:
+        instrumentUsed:
+        variablesIncluded: []
+
+
+  tableFields:
+  - Year: when sample was collected
+  - Matrix: tissue or sediment
+  - Cotam_group: contaminant group 
+  - Units: units of concentration
+  - Tot_conc: total concentration
+  - Nst_site: abbreviation of the sample site (station)
+  - Gen_loca: general location
+  - Spec_loc: specific location
+  - St_name: State Name
+  - Region: one of the five sample regions
+  - Lat_dd: Latitude in decimal degrees
+  - Lon_dd: Longitude in decimal degrees 
+  - Sample type: tissue or one of the bivalve species 
+  - Species name: general and latin name of the species 
+
+  Sample species (Spec_cd1):
+  - CV: Eastern oyster (Crassostrea virginica)
+  - OS: Hawaiian oyster (Dendostrea sandvichensis)
+  - CR: Mangrove cupped oyster (Crassostrea rhizophorae)
+  - CG: Pacific oyster (Crassostrea gigas)
+  - ME: Blue mussel (Mytilus edulis)
+  - MS: Mytilus/unidentified species
+  - MC: California mussel (Mytilus californianus)
+  - BaM: Bay mussel (Mytilus trossulus)
+  - MM: Mediterranean mussel (Mytilus galloprovincialis)
+  - DS: zebra mussels (Dreissena species)
+  - GD: Ribbed mussel (Geukensia demissa)
+  - CS: Black croaker (Cheilotrema saturnum)
+  - SP: Spot croaker (Leiostomus xanthurus)
+  - CN: Cockle (Clinocardium nuttallii)
+
+  Regions: 
+  - Great Lakes: zebra mussel (Dreissena polymorpha,  Pallas 1771) and quagga mussel (D. bugensis Andrusov, 1897), 
+  both which are invasive species  (Hebert et al. 1989; Mills et al. 1993).  
+  - Northeast: blue mussel (Mytilus edulis, Linnaeus 1758)
+  - Southeast: American oyster (Crassostrea virginica, Gmelin, 1791); 
+  - Puerto Rico: mangrove oyster (Crassostrea  rhizophorae, Guilding, 1828).
+  - Gulf of Mexico: American oyster (Crassostrea virginica, Gmelin, 1791)
+  - West Coast, Alaska: Mytilus species (Mytilus sp.=M. galloprovinciallis & M. trossulus), California mussel 
+  (M.  californianus, Conrad 1837)
+  - Hawaii: Hawaiian oyster (Dendostrea sandvichensis, Sowerby, 1871) 
+
+
+    # seaLevel:
+    #   measurementFrequency:
+    #   datumUsed: {}
+    #   # - name: foo
+    #   #   description: bar
+    #   variablesIncluded: []
+
+    # marineChemistry:
+    #   chemicalParameters:
+    #   samplingMethod:
+    #   variablesIncluded: []
+
+    # biological:
+    #   speciesCovered:
+    #   samplingMethod:
+    #   taxonomicInformation:
+    #   variablesIncluded: []
+
+    # acoustic:
+    #   frequencyRange:
+    #     min:
+    #     max:
+    #   instrumentType:
+    #   variablesIncluded: []


### PR DESCRIPTION
The Coastal Pollution Data Explorer (CPDE) is an interactive web-based interface where users can explore spatial and temporal trends of chemical, physical, biological, and toxicological data. Users can compare, analyze, graph, and download NCCOS contaminant data from 1986 to the present. The Mussel Watch program monitors the status and trends of chemical contaminants and biological stressors in coastal waters.

[Download Link](https://experience.arcgis.com/experience/e5ae2ee667e640c99ed85834291e83b2/page/Explore-All-MW-data/?views=Download-Data%2CLegacy)

![image (8)](https://github.com/user-attachments/assets/7714bb0d-56fb-4f28-b50c-31f128afcee4)
